### PR TITLE
Fixed a bug where volume could not reach 0%.

### DIFF
--- a/src/pa_object.cpp
+++ b/src/pa_object.cpp
@@ -55,11 +55,12 @@ void PaObject::set_volume(float perc)
 
 void PaObject::step_volume(int dir)
 {
-    if (volume <= 1000 && dir == -1) {
+    if (volume < 0x400 && dir == -1) {
+        set_volume(0);
         return;
     }
 
-    set_volume(static_cast<float>(volume + (1000 * dir)) / PA_VOLUME_NORM);
+    set_volume(static_cast<float>(volume + (0x400 * dir)) / PA_VOLUME_NORM);
 }
 
 


### PR DESCRIPTION
Fixed a bug where the volume could not go below 1%. Moreover changes the step size from 1000 to 1024, because 1024 is a factor of PA_VOLUME_NORM. This divides the volume from 0% to 100% into 64 equally sized gaps of 1024, instead of 66.536 gaps of 1000.